### PR TITLE
Include ECS API message in exception during login

### DIFF
--- a/ecsminion/util/token_request.py
+++ b/ecsminion/util/token_request.py
@@ -77,12 +77,14 @@ class TokenRequest(object):
             log.fatal(msg)
             raise ECSMinionException(
                 http_status_code=req.status_code,
+                ecs_message=req.text,
                 message=msg)
         if req.status_code != 200:
             msg = 'Non-200 status returned ({0})'.format(req.status_code)
             log.fatal(msg)
             raise ECSMinionException(
                 http_status_code=req.status_code,
+                ecs_message=req.text,
                 message=msg)
 
         token = req.headers['x-sds-auth-token']


### PR DESCRIPTION
Previously I was receiving this error from ECSMinion:

``` python
ecsminion.util.exceptions.ECSMinionException: ('Non-200 status returned (497)', 497, None)
```

and with this change, I now receive better info:

``` python
ecsminion.util.exceptions.ECSMinionException: ('Non-200 status returned (497)', 497,
u'{\n  "code": 6497,\n  "description": "HTTP To HTTPS",\n  "details": "Plain HTTP sent to HTTPS port.",\n  "retryable": false\n}\n')
```

This instantly helped me realize what the actual problem was!
