### PR TITLE
Allow token to still work when cache_token is false

### DIFF
--- a/ecsminion/__init__.py
+++ b/ecsminion/__init__.py
@@ -56,6 +56,7 @@ requests.packages.urllib3.disable_warnings()
 
 # Initialize logger
 log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class ECSMinion(object):


### PR DESCRIPTION
When token caching is disabled, the retrieved token is ignored, and a new token is requested for every additional API call.  This PR should alleviate the issue.
