### PR TITLE
Verify the token directory exist

### DIFF
--- a/ecsminion/util/token_request.py
+++ b/ecsminion/util/token_request.py
@@ -92,6 +92,10 @@ class TokenRequest(object):
 
         if self.cache_token:
             log.debug("Caching token to '{0}'".format(self.token_file))
+
+            if os.path.isdir(self.token_location) is False:
+                raise ECSMinionException('Token directory not found.')
+
             with open(self.token_file, 'w') as token_file:
                 token_file.write(self.token)
 


### PR DESCRIPTION
There is a bug when the /tmp directory doesn't exist.  The application continues even when the token file can't be created, this causes the application to keep pulling new tokens (multiple login attempts) until you exhaust all your available ones.